### PR TITLE
Fix TypeError on null data in unknown external plugins

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -526,6 +526,7 @@ function handleUnknownPlugins(unknownDasPlugins?: Record<string, any>[]) {
 
   return unknownDasPlugins.reduce((acc: PluginsList, unknownPlugin) => {
     if (!PluginType[unknownPlugin.type]) return acc;
+    if (unknownPlugin.data == null) return acc;
 
     const deserializedPlugin = getPluginSerializer().deserialize(
       base64.serialize(unknownPlugin.data)
@@ -559,6 +560,7 @@ function handleUnknownExternalPlugins(
   return unknownDasPlugins.reduce(
     (acc: ExternalPluginAdaptersList, unknownPlugin) => {
       if (!ExternalPluginAdapterType[unknownPlugin.type]) return acc;
+      if (unknownPlugin.data == null) return acc;
 
       const deserializedPlugin =
         getExternalPluginAdapterSerializer().deserialize(


### PR DESCRIPTION
## Summary

- Adds null checks before `base64.serialize(unknownPlugin.data)` in both `handleUnknownPlugins` and `handleUnknownExternalPlugins` to prevent `TypeError: Cannot read properties of null (reading 'replace')`
- DAS providers return `data: null` for AgentIdentity external plugins (type 6, added in mpl-core 1.8.0) that haven't been fully indexed yet — plugins with null data are now safely skipped

## Test plan

- [ ] Verify that assets with AgentIdentity external plugins (type 6, data: null) no longer throw
- [ ] Verify that assets with populated unknown plugin data still deserialize correctly
- [ ] Run existing test suite to confirm no regressions

https://claude.ai/code/session_01TeLg2WS1YxYzQDkaskvQ8r